### PR TITLE
feat(WorkRecordValidator): CADと設計の工程を検証対象に追加

### DIFF
--- a/AchieveTrack/AchieveTrack.csproj
+++ b/AchieveTrack/AchieveTrack.csproj
@@ -3,7 +3,7 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>net8.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
-    <VersionPrefix>1.2.3</VersionPrefix>
+    <VersionPrefix>1.2.4</VersionPrefix>
     <ApplicationIcon>Material-Cassette.ico</ApplicationIcon>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/Wada.AchieveTrackService/WorkRecordValidator/WorkRecordValidator.cs
+++ b/Wada.AchieveTrackService/WorkRecordValidator/WorkRecordValidator.cs
@@ -12,15 +12,15 @@ public class WorkRecordValidator(IWorkOrderRepository workOrderRepository,
                                  IDesignManagementRepository designManagementRepository)
     : IWorkRecordValidator
 {
+    private static readonly IReadOnlyCollection<string> CadProcessFlows = ["CAD", "設計"];
+
     [Logging]
     public async Task<IEnumerable<IEnumerable<IValidationError>>> ValidateWorkRecordsAsync(IEnumerable<WorkRecord> workRecords)
     {
         if (!workRecords.Any())
             throw new ArgumentNullException(nameof(workRecords));
 
-        const string CadProcessFlow = "CAD";
-
-        return await Task.WhenAll((IEnumerable<Task<List<IValidationError>>>)workRecords.Select(
+        return await Task.WhenAll(workRecords.Select(
             async x =>
             {
                 var validationResults = new List<IValidationError>();
@@ -30,7 +30,7 @@ public class WorkRecordValidator(IWorkOrderRepository workOrderRepository,
                     if (await IsWorkingDatePastCompletionAsync(x.WorkOrderId, x.WorkingDate))
                         validationResults.Add(WorkDateExpiredError.Create(x.WorkOrderId, x.JigCode, x.Note));
 
-                    if (x.ProcessFlow == CadProcessFlow
+                    if (CadProcessFlows.Contains(x.ProcessFlow)
                         && !await IsWorkNumberInDesignManagementLedgerAsync(x.WorkOrderId))
                         validationResults.Add(UnregisteredWorkOrderIdError.Create(x.WorkOrderId, x.JigCode, x.Note));
                 }

--- a/Wada.AchieveTrackServiceTests/WorkRecordValidator/WorkRecordValidatorTests.cs
+++ b/Wada.AchieveTrackServiceTests/WorkRecordValidator/WorkRecordValidatorTests.cs
@@ -6,186 +6,234 @@ using Wada.AchieveTrackService.ValueObjects;
 using Wada.AchieveTrackService.WorkOrderAggregation;
 using Wada.AchieveTrackService.WorkRecordReader;
 
-namespace Wada.AchieveTrackService.WorkRecordValidator.Tests
+namespace Wada.AchieveTrackService.WorkRecordValidator.Tests;
+
+[TestClass()]
+public class WorkRecordValidatorTests
 {
-    [TestClass()]
-    public class WorkRecordValidatorTests
+    [TestMethod()]
+    public async Task 正常系_作業日報の検証が通ること()
     {
-        [TestMethod()]
-        public async Task 正常系_作業日報の検証が通ること()
+        // given
+        List<WorkRecord> workRecords =
+        [
+            TestWorkRecordFactory.Create(processFlow: "CAD"),
+            TestWorkRecordFactory.Create(processFlow: "設計"),
+            TestWorkRecordFactory.Create(processFlow: "CAD"),
+        ];
+
+        var workOrder = TestWorkOrderFactory.Create();
+
+        Mock<IWorkOrderRepository> workOrderMock = new();
+        workOrderMock.Setup(x => x.FindByWorkOrderIdAsync(It.IsAny<WorkOrderId>()))
+            .ReturnsAsync(workOrder);
+
+        Mock<IAchievementLedgerRepository> achievementMock = new();
+        achievementMock.Setup(x => x.FindByWorkingDateAndEmployeeNumberAsync(It.IsAny<DateTime>(), It.IsAny<uint>()))
+            .ThrowsAsync(new AchievementLedgerAggregationException());
+
+        Mock<IDesignManagementRepository> designMock = new();
+
+        // when
+        WorkRecordValidator validator = new(workOrderMock.Object,
+                                            achievementMock.Object,
+                                            designMock.Object);
+        var actual = await validator.ValidateWorkRecordsAsync(workRecords);
+
+        // then
+        Assert.IsFalse(actual.SelectMany(x => x).Any());
+        workOrderMock.Verify(
+            x => x.FindByWorkOrderIdAsync(It.IsAny<WorkOrderId>()), Times.Exactly(3 * workRecords.Count));
+        achievementMock.Verify(
+            x => x.FindByWorkingDateAndEmployeeNumberAsync(It.IsAny<DateTime>(),
+                                                           It.IsAny<uint>()), Times.Exactly(workRecords.Count));
+        designMock.Verify(
+            x => x.FindByOwnCompanyNumberAsync(It.IsAny<uint>()), Times.Exactly(workRecords.Count));
+    }
+
+    [TestMethod()]
+    public async Task 正常系_作業台帳にない_実績台帳に登録済みの異常があることを検出すること()
+    {
+        // given
+        List<WorkRecord> workRecords =
+        [
+            TestWorkRecordFactory.Create(),
+        ];
+
+        Mock<IWorkOrderRepository> workOrderMock = new();
+        workOrderMock.Setup(x => x.FindByWorkOrderIdAsync(It.IsAny<WorkOrderId>()))
+            .ThrowsAsync(new WorkOrderNotFoundException());
+
+        Mock<IAchievementLedgerRepository> achievementMock = new();
+
+        Mock<IDesignManagementRepository> designMock = new();
+
+        // when
+        IWorkRecordValidator validator = new WorkRecordValidator(workOrderMock.Object,
+                                                                 achievementMock.Object,
+                                                                 designMock.Object);
+        var results = await validator.ValidateWorkRecordsAsync(workRecords);
+
+        // then
+        var expected = workRecords.First();
+        var actual = results.SelectMany(x => x);
+        Assert.IsTrue(actual.Any(x => typeof(InvalidWorkOrderIdError) == x.GetType()));
+        Assert.IsTrue(actual.Any(x => typeof(DuplicateWorkDateEmployeeError) == x.GetType()));
+        actual.ToList().ForEach(x =>
         {
-            // given
-            List<WorkRecord> workRecords = new()
-            {
-                TestWorkRecordFactory.Create(processFlow: "CAD"),
-                TestWorkRecordFactory.Create(processFlow: "CAD"),
-                TestWorkRecordFactory.Create(processFlow: "CAD"),
-            };
+            Assert.AreEqual(expected.WorkOrderId.Value, x.WorkOrderId.Value);
+            Assert.AreEqual(expected.Note, x.Note);
+        });
 
-            var workOrder = TestWorkOrderFactory.Create();
+        workOrderMock.Verify(
+            x => x.FindByWorkOrderIdAsync(It.IsAny<WorkOrderId>()), Times.Once);
+        achievementMock.Verify(
+            x => x.FindByWorkingDateAndEmployeeNumberAsync(It.IsAny<DateTime>(),
+                                                           It.IsAny<uint>()), Times.Once);
+        designMock.Verify(
+            x => x.FindByOwnCompanyNumberAsync(It.IsAny<uint>()), Times.Never);
+    }
 
-            Mock<IWorkOrderRepository> workOrderMock = new();
-            workOrderMock.Setup(x => x.FindByWorkOrderIdAsync(It.IsAny<WorkOrderId>()))
-                .ReturnsAsync(workOrder);
+    [TestMethod()]
+    public async Task 正常系_完成日過ぎている_設計管理に登録されていない_実績台帳に登録済みの異常があることを検出すること()
+    {
+        // given
+        var workingDate = new DateTime(2023, 4, 1);
+        List<WorkRecord> workRecords =
+        [
+            TestWorkRecordFactory.Create(workingDate: workingDate,
+                                         processFlow: "CAD"),
+        ];
+        var workOrder = TestWorkOrderFactory.Create(completionDate: workingDate.AddDays(-1));
 
-            Mock<IAchievementLedgerRepository> achievementMock = new();
-            achievementMock.Setup(x => x.FindByWorkingDateAndEmployeeNumberAsync(It.IsAny<DateTime>(), It.IsAny<uint>()))
-                .ThrowsAsync(new AchievementLedgerAggregationException());
+        Mock<IWorkOrderRepository> workOrderMock = new();
+        workOrderMock.Setup(x => x.FindByWorkOrderIdAsync(It.IsAny<WorkOrderId>()))
+            .ReturnsAsync(workOrder);
 
-            Mock<IDesignManagementRepository> designMock = new();
+        Mock<IAchievementLedgerRepository> achievementMock = new();
 
-            // when
-            WorkRecordValidator validator = new(workOrderMock.Object,
-                                                achievementMock.Object,
-                                                designMock.Object);
-            var actual = await validator.ValidateWorkRecordsAsync(workRecords);
+        Mock<IDesignManagementRepository> designMock = new();
+        designMock.Setup(x => x.FindByOwnCompanyNumberAsync(It.IsAny<uint>()))
+            .ThrowsAsync(new DesignManagementNotFoundException());
 
-            // then
-            Assert.IsFalse(actual.SelectMany(x => x).Any());
-            workOrderMock.Verify(
-                x => x.FindByWorkOrderIdAsync(It.IsAny<WorkOrderId>()), Times.Exactly(3 * workRecords.Count));
-            achievementMock.Verify(
-                x => x.FindByWorkingDateAndEmployeeNumberAsync(It.IsAny<DateTime>(),
-                                                               It.IsAny<uint>()), Times.Exactly(workRecords.Count));
-            designMock.Verify(
-                x => x.FindByOwnCompanyNumberAsync(It.IsAny<uint>()), Times.Exactly(workRecords.Count));
-        }
+        // when
+        IWorkRecordValidator validator = new WorkRecordValidator(workOrderMock.Object,
+                                                                 achievementMock.Object,
+                                                                 designMock.Object);
+        var results = await validator.ValidateWorkRecordsAsync(workRecords);
 
-        [TestMethod()]
-        public async Task 正常系_作業台帳にない_実績台帳に登録済みの異常があることを検出すること()
+        // then
+        var expected = workRecords.First();
+        var actual = results.SelectMany(x => x);
+        Assert.IsTrue(actual.Any(x => typeof(WorkDateExpiredError) == x.GetType()));
+        Assert.IsTrue(actual.Any(x => typeof(UnregisteredWorkOrderIdError) == x.GetType()));
+        Assert.IsTrue(actual.Any(x => typeof(DuplicateWorkDateEmployeeError) == x.GetType()));
+        actual.ToList().ForEach(x =>
         {
-            // given
-            List<WorkRecord> workRecords = new()
-            {
-                TestWorkRecordFactory.Create(),
-            };
+            Assert.AreEqual(expected.WorkOrderId.Value, x.WorkOrderId.Value);
+            Assert.AreEqual(expected.Note, x.Note);
+        });
 
-            Mock<IWorkOrderRepository> workOrderMock = new();
-            workOrderMock.Setup(x => x.FindByWorkOrderIdAsync(It.IsAny<WorkOrderId>()))
-                .ThrowsAsync(new WorkOrderNotFoundException());
+        workOrderMock.Verify(
+            x => x.FindByWorkOrderIdAsync(It.IsAny<WorkOrderId>()), Times.Exactly(3 * workRecords.Count));
+        achievementMock.Verify(
+            x => x.FindByWorkingDateAndEmployeeNumberAsync(It.IsAny<DateTime>(),
+                                                           It.IsAny<uint>()), Times.Once);
+        designMock.Verify(
+            x => x.FindByOwnCompanyNumberAsync(It.IsAny<uint>()), Times.Exactly(workRecords.Count));
+    }
 
-            Mock<IAchievementLedgerRepository> achievementMock = new();
+    [TestMethod()]
+    public async Task 正常系_作業日が完成日を過ぎていることを検出すること()
+    {
+        // given
+        var workingDate = new DateTime(2023, 4, 1);
+        List<WorkRecord> workRecords =
+        [
+            TestWorkRecordFactory.Create(workingDate: workingDate,
+                                         processFlow: "CAD"),
+        ];
+        var workOrder = TestWorkOrderFactory.Create(completionDate: workingDate.AddDays(-1));
 
-            Mock<IDesignManagementRepository> designMock = new();
+        Mock<IWorkOrderRepository> workOrderMock = new();
+        workOrderMock.Setup(x => x.FindByWorkOrderIdAsync(It.IsAny<WorkOrderId>()))
+            .ReturnsAsync(workOrder);
 
-            // when
-            IWorkRecordValidator validator = new WorkRecordValidator(workOrderMock.Object,
-                                                                     achievementMock.Object,
-                                                                     designMock.Object);
-            var results = await validator.ValidateWorkRecordsAsync(workRecords);
+        Mock<IAchievementLedgerRepository> achievementMock = new();
 
-            // then
-            var expected = workRecords.First();
-            var actual = results.SelectMany(x => x);
-            Assert.IsTrue(actual.Any(x => typeof(InvalidWorkOrderIdError) == x.GetType()));
-            Assert.IsTrue(actual.Any(x => typeof(DuplicateWorkDateEmployeeError) == x.GetType()));
-            actual.ToList().ForEach(x =>
-            {
-                Assert.AreEqual(expected.WorkOrderId.Value, x.WorkOrderId.Value);
-                Assert.AreEqual(expected.Note, x.Note);
-            });
+        Mock<IDesignManagementRepository> designMock = new();
 
-            workOrderMock.Verify(
-                x => x.FindByWorkOrderIdAsync(It.IsAny<WorkOrderId>()), Times.Once);
-            achievementMock.Verify(
-                x => x.FindByWorkingDateAndEmployeeNumberAsync(It.IsAny<DateTime>(),
-                                                               It.IsAny<uint>()), Times.Once);
-            designMock.Verify(
-                x => x.FindByOwnCompanyNumberAsync(It.IsAny<uint>()), Times.Never);
-        }
+        // when
+        IWorkRecordValidator validator = new WorkRecordValidator(workOrderMock.Object,
+                                                                 achievementMock.Object,
+                                                                 designMock.Object);
+        var results = await validator.ValidateWorkRecordsAsync(workRecords);
 
-        [TestMethod()]
-        public async Task 正常系_完成日過ぎている_設計管理に登録されていない_実績台帳に登録済みの異常があることを検出すること()
+        // then
+        var expected = workRecords.First();
+        var actual = results.SelectMany(x => x);
+        Assert.IsTrue(actual.Any(x => typeof(WorkDateExpiredError) == x.GetType()));
+        actual.ToList().ForEach(x =>
         {
-            // given
-            var workingDate = new DateTime(2023, 4, 1);
-            List<WorkRecord> workRecords = new()
-            {
-                TestWorkRecordFactory.Create(workingDate: workingDate,
-                                             processFlow: "CAD"),
-            };
-            var workOrder = TestWorkOrderFactory.Create(completionDate: workingDate.AddDays(-1));
+            Assert.AreEqual(expected.WorkOrderId.Value, x.WorkOrderId.Value);
+            Assert.AreEqual(expected.Note, x.Note);
+        });
 
-            Mock<IWorkOrderRepository> workOrderMock = new();
-            workOrderMock.Setup(x => x.FindByWorkOrderIdAsync(It.IsAny<WorkOrderId>()))
-                .ReturnsAsync(workOrder);
+        workOrderMock.Verify(
+            x => x.FindByWorkOrderIdAsync(It.IsAny<WorkOrderId>()), Times.Exactly(3));
+        achievementMock.Verify(
+            x => x.FindByWorkingDateAndEmployeeNumberAsync(It.IsAny<DateTime>(),
+                                                           It.IsAny<uint>()), Times.Once);
+        designMock.Verify(
+            x => x.FindByOwnCompanyNumberAsync(It.IsAny<uint>()), Times.Once);
+    }
 
-            Mock<IAchievementLedgerRepository> achievementMock = new();
+    [TestMethod()]
+    public async Task 正常系_設計工程で完成日過ぎている_設計管理に登録されていない_実績台帳に登録済みの異常があることを検出すること()
+    {
+        // given
+        var workingDate = new DateTime(2023, 4, 1);
+        List<WorkRecord> workRecords =
+        [
+            TestWorkRecordFactory.Create(workingDate: workingDate,
+                                         processFlow: "設計"),
+        ];
+        var workOrder = TestWorkOrderFactory.Create(completionDate: workingDate.AddDays(-1));
 
-            Mock<IDesignManagementRepository> designMock = new();
-            designMock.Setup(x => x.FindByOwnCompanyNumberAsync(It.IsAny<uint>()))
-                .ThrowsAsync(new DesignManagementNotFoundException());
+        Mock<IWorkOrderRepository> workOrderMock = new();
+        workOrderMock.Setup(x => x.FindByWorkOrderIdAsync(It.IsAny<WorkOrderId>()))
+            .ReturnsAsync(workOrder);
 
-            // when
-            IWorkRecordValidator validator = new WorkRecordValidator(workOrderMock.Object,
-                                                                     achievementMock.Object,
-                                                                     designMock.Object);
-            var results = await validator.ValidateWorkRecordsAsync(workRecords);
+        Mock<IAchievementLedgerRepository> achievementMock = new();
 
-            // then
-            var expected = workRecords.First();
-            var actual = results.SelectMany(x => x);
-            Assert.IsTrue(actual.Any(x => typeof(WorkDateExpiredError) == x.GetType()));
-            Assert.IsTrue(actual.Any(x => typeof(UnregisteredWorkOrderIdError) == x.GetType()));
-            Assert.IsTrue(actual.Any(x => typeof(DuplicateWorkDateEmployeeError) == x.GetType()));
-            actual.ToList().ForEach(x =>
-            {
-                Assert.AreEqual(expected.WorkOrderId.Value, x.WorkOrderId.Value);
-                Assert.AreEqual(expected.Note, x.Note);
-            });
+        Mock<IDesignManagementRepository> designMock = new();
+        designMock.Setup(x => x.FindByOwnCompanyNumberAsync(It.IsAny<uint>()))
+            .ThrowsAsync(new DesignManagementNotFoundException());
 
-            workOrderMock.Verify(
-                x => x.FindByWorkOrderIdAsync(It.IsAny<WorkOrderId>()), Times.Exactly(3 * workRecords.Count));
-            achievementMock.Verify(
-                x => x.FindByWorkingDateAndEmployeeNumberAsync(It.IsAny<DateTime>(),
-                                                               It.IsAny<uint>()), Times.Once);
-            designMock.Verify(
-                x => x.FindByOwnCompanyNumberAsync(It.IsAny<uint>()), Times.Exactly(workRecords.Count));
-        }
+        // when
+        IWorkRecordValidator validator = new WorkRecordValidator(workOrderMock.Object,
+                                                                 achievementMock.Object,
+                                                                 designMock.Object);
+        var results = await validator.ValidateWorkRecordsAsync(workRecords);
 
-        [TestMethod()]
-        public async Task 正常系_作業日が完成日を過ぎていることを検出すること()
+        // then
+        var expected = workRecords.First();
+        var actual = results.SelectMany(x => x);
+        Assert.IsTrue(actual.Any(x => typeof(WorkDateExpiredError) == x.GetType()));
+        Assert.IsTrue(actual.Any(x => typeof(UnregisteredWorkOrderIdError) == x.GetType()));
+        Assert.IsTrue(actual.Any(x => typeof(DuplicateWorkDateEmployeeError) == x.GetType()));
+        actual.ToList().ForEach(x =>
         {
-            // given
-            var workingDate = new DateTime(2023, 4, 1);
-            List<WorkRecord> workRecords = new()
-            {
-                TestWorkRecordFactory.Create(workingDate: workingDate,
-                                             processFlow: "CAD"),
-            };
-            var workOrder = TestWorkOrderFactory.Create(completionDate: workingDate.AddDays(-1));
+            Assert.AreEqual(expected.WorkOrderId.Value, x.WorkOrderId.Value);
+            Assert.AreEqual(expected.Note, x.Note);
+        });
 
-            Mock<IWorkOrderRepository> workOrderMock = new();
-            workOrderMock.Setup(x => x.FindByWorkOrderIdAsync(It.IsAny<WorkOrderId>()))
-                .ReturnsAsync(workOrder);
-
-            Mock<IAchievementLedgerRepository> achievementMock = new();
-
-            Mock<IDesignManagementRepository> designMock = new();
-
-            // when
-            IWorkRecordValidator validator = new WorkRecordValidator(workOrderMock.Object,
-                                                                     achievementMock.Object,
-                                                                     designMock.Object);
-            var results = await validator.ValidateWorkRecordsAsync(workRecords);
-
-            // then
-            var expected = workRecords.First();
-            var actual = results.SelectMany(x => x);
-            Assert.IsTrue(actual.Any(x => typeof(WorkDateExpiredError) == x.GetType()));
-            actual.ToList().ForEach(x =>
-            {
-                Assert.AreEqual(expected.WorkOrderId.Value, x.WorkOrderId.Value);
-                Assert.AreEqual(expected.Note, x.Note);
-            });
-
-            workOrderMock.Verify(
-                x => x.FindByWorkOrderIdAsync(It.IsAny<WorkOrderId>()), Times.Exactly(3));
-            achievementMock.Verify(
-                x => x.FindByWorkingDateAndEmployeeNumberAsync(It.IsAny<DateTime>(),
-                                                               It.IsAny<uint>()), Times.Once);
-            designMock.Verify(
-                x => x.FindByOwnCompanyNumberAsync(It.IsAny<uint>()), Times.Once);
-        }
+        workOrderMock.Verify(
+            x => x.FindByWorkOrderIdAsync(It.IsAny<WorkOrderId>()), Times.Exactly(3 * workRecords.Count));
+        achievementMock.Verify(
+            x => x.FindByWorkingDateAndEmployeeNumberAsync(It.IsAny<DateTime>(),
+                                                           It.IsAny<uint>()), Times.Once);
+        designMock.Verify(
+            x => x.FindByOwnCompanyNumberAsync(It.IsAny<uint>()), Times.Exactly(workRecords.Count));
     }
 }


### PR DESCRIPTION
作業日報の検証において、工程が "CAD" または "設計" の場合に、設計管理台帳のチェックを行うように修正しました。

- マジックナンバーを避け、保守性を向上させるため、検証対象の工程を定数として定義しました。
- "設計" 工程の検証が正しく行われることを確認するための単体テストを追加しました。